### PR TITLE
Added some vulkan/directx12 stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A curated list of useful tools, libraries, resources all around the topic of gam
 - [RenderDoc](https://renderdoc.org/) Render Debugger
   - [Where is my Draw](https://github.com/baldurk/renderdoc-contrib/tree/main/baldurk/whereismydraw) Addon for RenderDoc
 - [NVIDIA® Nsight™ Graphics](https://developer.nvidia.com/nsight-graphics) is a standalone developer tool that enables you to debug, profile, and export frames built with Direct3D (11, 12, DXR), Vulkan (1.2, NV Vulkan Ray Tracing Extension), OpenGL, OpenVR, and the Oculus SDK.
-- [Rider for UE4] (https://www.jetbrains.com/lp/rider-unreal/) Visual Studio alternative for UE4 with useful functionality like built-in visual assist features and showing where classes are implemented in blueprints. 
+- [Rider for UE4](https://www.jetbrains.com/lp/rider-unreal/) Visual Studio alternative for UE4 with useful functionality like built-in visual assist features and showing where classes are implemented in blueprints. 
 - [MTuner](https://github.com/milostosic/MTuner)  is a C/C++ memory profiler and memory leak finder for Windows, PlayStation 4 and 3, Android and other platforms
 - [optick](https://github.com/bombomby/optick) C++ Profiler For Games
 - [Agones](https://github.com/googleforgames/agones) Host, Run and Scale dedicated game servers on Kubernetes
@@ -77,7 +77,7 @@ A curated list of useful tools, libraries, resources all around the topic of gam
 - [Assimp](https://github.com/assimp/assimp) The official Open-Asset-Importer-Library Repository. Loads 40+ 3D-file-formats into one unified and clean data structure.
 - [DiligentEngine](https://github.com/DiligentGraphics/DiligentEngine) A modern cross-platform low-level graphics library and rendering framework
 - [Vulkan Memory Allocator](https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator) Easy to integrate Vulkan memory allocation library
-- [Directx12 Memory Allocator](https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator) Easy to integrate directx12 memory allocation library, from the makers of Vulkan Memory Allocator.
+- [Directx12 Memory Allocator](https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator) Easy to integrate directx12 memory allocation library, from the creators of Vulkan Memory Allocator.
 - [FidelityFX](https://github.com/GPUOpen-Effects/FidelityFX) Optimized shader-based features aimed at improving rendering quality and performance.
 
 #### rust

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ A curated list of useful tools, libraries, resources all around the topic of gam
 - [Assimp](https://github.com/assimp/assimp) The official Open-Asset-Importer-Library Repository. Loads 40+ 3D-file-formats into one unified and clean data structure.
 - [DiligentEngine](https://github.com/DiligentGraphics/DiligentEngine) A modern cross-platform low-level graphics library and rendering framework
 - [Vulkan Memory Allocator](https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator) Easy to integrate Vulkan memory allocation library
+- [Directx12 Memory Allocator](https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator) Easy to integrate directx12 memory allocation library, from the makers of Vulkan Memory Allocator.
 - [FidelityFX](https://github.com/GPUOpen-Effects/FidelityFX) Optimized shader-based features aimed at improving rendering quality and performance.
 
 #### rust
@@ -376,8 +377,16 @@ implementations](https://www.cs.ru.nl/bachelors-theses/2018/Niels_Drueten___4496
 - [Scratchapixel 2.0](https://www.scratchapixel.com/) Learn Computer Graphics From Scratch!
 - [vulkan-tutorial.com](https://vulkan-tutorial.com/) - A collection of vulkan tutorials
 - [VulkanGuide](https://vkguide.dev/) - The focus of this guide is to understand Vulkan correctly, and act as a stepping stone for then working in your own projects
+- [Vulkan for HLSL](https://www.lei.chat/posts/hlsl-for-vulkan-resources/) How to use HLSL for Vulkan Shaders when compiling HLSL to SPIR-V using [DirectXShaderCompiler](https://github.com/microsoft/DirectXShaderCompiler).
 - [tellusim engine blog](https://tellusim.com/blog/) - cool GPU driven blog posts: Blue noise, benchmarks between GPU's, Raytracing, Animations etc.
 - [The Danger Zone](https://therealmjp.github.io/) Blog of Matt Pettineo (Lead graphics and engine programmer at Ready At Dawn Studios)
+such as Vulkan, Directx11/12 and opengl.
+- [Alain Galvan blogs](https://alain.xyz/) Blog of Alain Galvan, graphics driver engineer for AMD.
+  - [Raw Directx12](https://alain.xyz/blog/raw-directx12) Basics on the raw initialization of Directx12 without any helper libraries.
+  - [Raw WebGPU](https://alain.xyz/blog/raw-webgpu) Basics on the raw initialization of WebGPU.
+  - [Raw Vulkan](https://alain.xyz/blog/raw-vulkan) Basics on the raw initialization of Vulkan.
+  - [Comparison of Modern Graphics API's](https://alain.xyz/blog/comparison-of-modern-graphics-apis) Goes on the basics, and differences on old and newer graphic API's 
+
 
 *Web tools*
 - [Compiler Explorer](https://godbolt.org/) - lets you compile many different languages such as C,C++ or rust and inspect the Assembly or test

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ A curated list of useful tools, libraries, resources all around the topic of gam
   - [stb_image_write.h](https://github.com/nothings/stb/blob/master/stb_image_write.h) image writer
   - [stb_image_resize.h](stb_image_resize.h) image resizer
   - [stb_truetype.h](stb_truetype.h) font text rasterizer
- - [DirectXShaderCompiler](https://github.com/microsoft/DirectXShaderCompiler) This repo hosts the source for the DirectX Shader Compiler which is based on LLVM/Clang.
+- [DirectXShaderCompiler](https://github.com/microsoft/DirectXShaderCompiler) This repo hosts the source for the DirectX Shader Compiler which is based on LLVM/Clang.
 - [Assimp](https://github.com/assimp/assimp) The official Open-Asset-Importer-Library Repository. Loads 40+ 3D-file-formats into one unified and clean data structure.
 - [DiligentEngine](https://github.com/DiligentGraphics/DiligentEngine) A modern cross-platform low-level graphics library and rendering framework
 - [Vulkan Memory Allocator](https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator) Easy to integrate Vulkan memory allocation library
@@ -378,6 +378,7 @@ implementations](https://www.cs.ru.nl/bachelors-theses/2018/Niels_Drueten___4496
 - [vulkan-tutorial.com](https://vulkan-tutorial.com/) - A collection of vulkan tutorials
 - [VulkanGuide](https://vkguide.dev/) - The focus of this guide is to understand Vulkan correctly, and act as a stepping stone for then working in your own projects
 - [Vulkan for HLSL](https://www.lei.chat/posts/hlsl-for-vulkan-resources/) How to use HLSL for Vulkan Shaders when compiling HLSL to SPIR-V using [DirectXShaderCompiler](https://github.com/microsoft/DirectXShaderCompiler).
+- [Using the DirectXShaderCompiler API](https://simoncoenen.com/blog/programming/graphics/DxcCompiling) explains how to use the DirectXShaderCompiler API in your application. Uses the new IDxcUtils interface instead of IDxcLibrary
 - [tellusim engine blog](https://tellusim.com/blog/) - cool GPU driven blog posts: Blue noise, benchmarks between GPU's, Raytracing, Animations etc.
 - [The Danger Zone](https://therealmjp.github.io/) Blog of Matt Pettineo (Lead graphics and engine programmer at Ready At Dawn Studios)
 such as Vulkan, Directx11/12 and opengl.


### PR DESCRIPTION
Contents:

- Alain Galvan with his RAW blogs that focus on the pure types without abstraction of graphics API's
- Alain Galvan on the comparison between graphic API's. (May be considered outdated due to Vulkan 1.3, but still valuable).
- HLSL for Vulkan guide
- Directx12 memory allocator (by the creators of Vulkan Memory Allocator)
- DirectX Shader Compiler how to use the modern version.
